### PR TITLE
adhoc update.

### DIFF
--- a/src/BclExtensionPack.Mail/BclExtensionPack.Mail.csproj
+++ b/src/BclExtensionPack.Mail/BclExtensionPack.Mail.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <Version>0.4.3</Version>
+    <Version>0.4.4</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Vitae</Authors>
     <Company>Vitae</Company>
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="3.4.3" />
+    <PackageReference Include="MailKit" Version="3.6.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="docs\README.md" Pack="true" PackagePath="\" />

--- a/src/BclExtensionPack.Mail/Configuration.cs
+++ b/src/BclExtensionPack.Mail/Configuration.cs
@@ -1,4 +1,5 @@
 using MailKit.Security;
+using MimeKit;
 
 namespace BclExtensionPack.Mail;
 public class Configuration {
@@ -22,4 +23,7 @@ public class Configuration {
             ? secureSocketOptionEnum
             : SecureSocketOptions.StartTlsWhenAvailable;
     }
+
+    public static void RelaxParserConstraints() =>
+        ParserOptions.Default.AddressParserComplianceMode = RfcComplianceMode.Looser;
 }


### PR DESCRIPTION
# 変更したもの
ParserOptions.Default.AddressParserComplianceModeに関してより緩いレベルに変更するメソッドを追加

## 追加意図
メールアドレスがrfc準拠ではないものを受け入れたいユースケースに対応するため。

## まだ対応していないこと
サービスパイプラインの拡張メソッド化。
本来なら上記の方針で書くべきなのだが、今回はadhocな対応を行った。(時間がなかったので。)
今回追加したメソッドはあくまでもParserOptions.Default.AddressParserComplianceModeの切り替えになるため、startupのようなサービスパイプライン管理を行うようなオブジェクトのメソッド内などで発火が望ましい。

今後はサービスパイプライン構築のメソッドチェーン内に含められるように変更を行う。